### PR TITLE
[JB-9248] NUI Theming Causing Crash on iOS 14

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ DerivedData
 
 Carthage
 Pods/
+.idea/

--- a/NUI/Core/NUISwizzler.m
+++ b/NUI/Core/NUISwizzler.m
@@ -16,7 +16,7 @@
     [self swizzleDidMoveToWindow:[UIBarButtonItem class]];
     [self swizzleDidMoveToWindow:[UIButton class]];
     [self swizzleDidMoveToWindow:[UILabel class]];
-    [self swizzleDidMoveToWindow:[UINavigationBar class]];
+    [self swizzleDidMovetoWindowWithClass:[UINavigationBar class]];
     [self swizzleDidMoveToWindow:[UINavigationItem class]];
     [self swizzleDidMoveToWindow:[UIProgressView class]];
     [self swizzleDidMoveToWindow:[UISearchBar class]];
@@ -49,6 +49,13 @@
     [self swizzleDealloc:[UITableViewCell class]];
     [self swizzleDealloc:[UITableView class]];
 }
+
+- (void)swizzleDidMovetoWindowWithClass:(Class)class{
+    NSString* methodName = @"didMoveToWindow";
+    SEL originalMethod = NSSelectorFromString(methodName);
+    SEL newMethod = NSSelectorFromString([NSString stringWithFormat:@"%@%@_%@", @"override_", class, methodName]);
+    [self swizzle:class from:originalMethod to:newMethod];
+};
 
 - (void)swizzleDidMoveToWindow:(Class)class
 {

--- a/NUI/UI/UINavigationBar+NUI.m
+++ b/NUI/UI/UINavigationBar+NUI.m
@@ -35,12 +35,12 @@
     self.nuiApplied = YES;
 }
 
-- (void)override_didMoveToWindow
+- (void)override_UINavigationBar_didMoveToWindow
 {
     if (!self.isNUIApplied) {
         [self applyNUI];
     }
-    [self override_didMoveToWindow];
+    [self override_UINavigationBar_didMoveToWindow];
 }
 
 - (void)override_dealloc {


### PR DESCRIPTION
### Fix ?
Link to ticket: https://joulebug.atlassian.net/browse/JB-9248

### What has been done
- Updated Swizzler to allow for more unique names and prevent recursive loop when both replacement methods have the same name

### How to test
- Point pod file to this branch
- run `bundle exec pod install` 
- run the app

### Acceptance criteria
- iOS 14 devices build and run without a crash related to UINavigationBar

### Notes
- Main issue and resolution found by rec from apple [here](https://developer.apple.com/forums/thread/649955)
- This will only fix the conflict on UINavigationBar, if we find others with the same issue, all other relevant NUI overrides will need to be updated. 